### PR TITLE
fix: repair Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,10 +1,10 @@
 name: Auto-merge Dependabot PRs
 
 on:
-  pull_request:
-    types: [opened, synchronize]
-  check_suite:
+  workflow_run:
+    workflows: ["Test, Coverage & Lint Check"]
     types: [completed]
+    branches: [main]
 
 permissions:
   contents: write
@@ -13,7 +13,9 @@ permissions:
 jobs:
   dependabot-auto-merge:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
     
     steps:
       - name: Checkout code
@@ -21,85 +23,83 @@ jobs:
 
       - name: Get PR information
         id: pr
-        uses: actions/github-script@v8
+        uses: actions/github-script@v7
         with:
           script: |
-            const response = await github.rest.pulls.get({
+            // Get the PR associated with this workflow run
+            const { data: pullRequests } = await github.rest.pulls.list({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: context.issue.number,
+              state: 'open',
+              head: `${context.repo.owner}:${context.payload.workflow_run.head_branch}`,
             });
-            console.log('PR Status:', response.data.state);
-            console.log('PR Author:', response.data.user.login);
-            return response.data;
+            
+            if (pullRequests.length === 0) {
+              console.log('No open PR found for this branch');
+              return null;
+            }
+            
+            const pr = pullRequests[0];
+            console.log('PR Number:', pr.number);
+            console.log('PR Author:', pr.user.login);
+            console.log('PR Title:', pr.title);
+            
+            return pr;
 
-      - name: Check if all checks passed
-        id: check-status
-        uses: actions/github-script@v8
+      - name: Check if PR is from Dependabot
+        id: check-dependabot
+        uses: actions/github-script@v7
         with:
           script: |
-            const { data: checkSuites } = await github.rest.checks.listSuitesForRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: context.payload.pull_request?.head.sha || context.payload.check_suite.head_sha,
-            });
+            const pr = ${{ steps.pr.outputs.result }};
             
-            // Get all check runs
-            const checks = await github.paginate(github.rest.checks.listForRef, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: context.payload.pull_request?.head.sha || context.payload.check_suite.head_sha,
-            });
+            if (!pr) {
+              console.log('❌ No PR found or PR was closed');
+              return false;
+            }
             
-            const allPassed = checks.every(check => 
-              check.status === 'completed' && 
-              (check.conclusion === 'success' || check.conclusion === 'neutral')
-            );
+            const isDependabot = pr.user.login === 'dependabot[bot]';
+            console.log('Is Dependabot PR:', isDependabot);
+            console.log('PR Author:', pr.user.login);
             
-            console.log(`Total checks: ${checks.length}`);
-            checks.forEach(check => {
-              console.log(`- ${check.name}: ${check.conclusion}`);
-            });
-            
-            return allPassed;
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            return isDependabot;
 
       - name: Enable auto-merge
-        if: steps.check-status.outputs.result == 'true'
-        uses: actions/github-script@v8
+        if: steps.check-dependabot.outputs.result == 'true'
+        id: auto-merge
+        uses: actions/github-script@v7
         with:
           script: |
-            const pullNumber = context.issue.number;
+            const pr = ${{ steps.pr.outputs.result }};
+            const pullNumber = pr.number;
             
             try {
               // Enable auto-merge with squash strategy
-              await github.graphql(
-                `mutation($input: EnablePullRequestAutoMergeInput!) {
-                  enablePullRequestAutoMerge(input: $input) {
-                    pullRequest {
-                      id
-                      autoMergeRequest {
-                        enabledAt
-                        enabledBy {
-                          login
-                        }
-                        mergeMethod
+              const mutation = `mutation($input: EnablePullRequestAutoMergeInput!) {
+                enablePullRequestAutoMerge(input: $input) {
+                  pullRequest {
+                    id
+                    autoMergeRequest {
+                      enabledAt
+                      enabledBy {
+                        login
                       }
+                      mergeMethod
                     }
                   }
-                }`,
-                {
-                  input: {
-                    pullRequestId: context.payload.pull_request?.node_id,
-                    mergeMethod: 'SQUASH',
-                    authorEmail: 'dependabot[bot]@users.noreply.github.com',
-                    commitHeadline: context.payload.pull_request?.title,
-                  },
+                }
+              }`;
+              
+              const result = await github.graphql(mutation, {
+                input: {
+                  pullRequestId: pr.node_id,
+                  mergeMethod: 'SQUASH',
+                  commitHeadline: pr.title,
                 },
-              );
+              });
               
               console.log('✅ Auto-merge enabled for Dependabot PR #' + pullNumber);
+              console.log('Merge method:', result.enablePullRequestAutoMerge.pullRequest.autoMergeRequest.mergeMethod);
               
               // Add a comment
               await github.rest.issues.createComment({
@@ -108,14 +108,32 @@ jobs:
                 issue_number: pullNumber,
                 body: '✅ All checks passed! This PR has been set to auto-merge with squash strategy.',
               });
+              
+              return true;
             } catch (error) {
-              console.log('ℹ️ Auto-merge might already be enabled or an error occurred:', error.message);
+              console.log('⚠️ Error enabling auto-merge:', error.message);
+              
+              // Try alternative approach if GraphQL fails
+              try {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pullNumber,
+                  body: '⚠️ All checks passed! Auto-merge could not be enabled automatically. Please enable it manually if needed.',
+                });
+              } catch (commentError) {
+                console.log('Could not create comment:', commentError.message);
+              }
+              
+              return false;
             }
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Log merge status
+      - name: Summary
         if: always()
         run: |
-          echo "Dependabot PR auto-merge workflow completed"
-          echo "All checks status: ${{ steps.check-status.outputs.result }}"
+          echo "## Auto-merge Workflow Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Workflow Run:** ${{ github.event.workflow_run.id }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Previous Workflow Status:** ${{ github.event.workflow_run.conclusion }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Auto-merge Enabled:** ${{ steps.auto-merge.outcome == 'success' && 'Yes ✅' || 'No ⚠️' }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Is Dependabot PR:** ${{ steps.check-dependabot.outputs.result == 'true' && 'Yes' || 'No' }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Fixes auto-merge by changing trigger from pull_request to workflow_run. This waits for tests to complete before checking status, preventing null conclusions.