### PR TITLE
feat: add configurable flag/tackle and timeout clocks

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -109,6 +109,7 @@ kover {
                 classes(
                     "yt.javi.gridirontimer.presentation.views.*",
                     "yt.javi.gridirontimer.presentation.theme.*",
+                    "yt.javi.gridirontimer.presentation.MainActivity",
                     "yt.javi.gridirontimer.presentation.*$*"
                 )
             }

--- a/app/src/main/java/yt/javi/gridirontimer/presentation/MainActivity.kt
+++ b/app/src/main/java/yt/javi/gridirontimer/presentation/MainActivity.kt
@@ -20,6 +20,7 @@ import androidx.wear.compose.navigation.SwipeDismissableNavHost
 import androidx.wear.compose.navigation.composable
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
 import yt.javi.gridirontimer.presentation.theme.GridironTimerTheme
+import yt.javi.gridirontimer.presentation.viewmodel.AppTimerSettings
 import yt.javi.gridirontimer.presentation.views.CustomTimerScreen
 import yt.javi.gridirontimer.presentation.views.MainScreen
 import yt.javi.gridirontimer.presentation.views.TimerScreen
@@ -69,8 +70,11 @@ class MainActivity : ComponentActivity() {
 
     sealed class Screen(val route: String) {
         object Main : Screen("main")
-        object Timer : Screen("timer/{duration}") {
-            fun createRoute(duration: Long) = "timer/$duration"
+        object Timer : Screen("timer/{duration}/{mode}") {
+            fun createRoute(duration: Long, isFlagMode: Boolean): String {
+                val mode = if (isFlagMode) "flag" else "tackle"
+                return "timer/$duration/$mode"
+            }
         }
 
         object CustomTimer : Screen("custom_timer")
@@ -86,14 +90,19 @@ class MainActivity : ComponentActivity() {
             composable(Screen.Main.route) { MainScreen(navController) }
             composable(
                 route = Screen.Timer.route,
-                arguments = listOf(navArgument("duration") { type = NavType.LongType })
+                arguments = listOf(
+                    navArgument("duration") { type = NavType.LongType },
+                    navArgument("mode") { type = NavType.StringType }
+                )
             ) { navBackStackEntry ->
                 val duration = navBackStackEntry.arguments?.getLong("duration") ?: 0L
-                val initialDuration = navBackStackEntry.arguments?.getLong("duration") ?: 0L
+                val mode = navBackStackEntry.arguments?.getString("mode") ?: "flag"
+                val isFlagMode = mode == "flag"
                 TimerScreen(
                     duration = duration,
                     navController = navController,
-                    initialDuration = initialDuration,
+                    isFlagMode = isFlagMode,
+                    timerConfig = AppTimerSettings.asTimerConfig(),
                     onStemPrimaryHandlerChange = { handler -> onStemPrimaryPressed = handler },
                     onStemPrimaryDoubleHandlerChange = { handler -> onStemPrimaryDoublePressed = handler }
                 )

--- a/app/src/main/java/yt/javi/gridirontimer/presentation/MainActivity.kt
+++ b/app/src/main/java/yt/javi/gridirontimer/presentation/MainActivity.kt
@@ -97,7 +97,7 @@ class MainActivity : ComponentActivity() {
             ) { navBackStackEntry ->
                 val duration = navBackStackEntry.arguments?.getLong("duration") ?: 0L
                 val mode = navBackStackEntry.arguments?.getString("mode") ?: "flag"
-                val isFlagMode = mode == "flag"
+                val isFlagMode = parseIsFlagMode(mode)
                 TimerScreen(
                     duration = duration,
                     navController = navController,
@@ -115,3 +115,5 @@ class MainActivity : ComponentActivity() {
         const val DOUBLE_PRESS_WINDOW_MS = 350L
     }
 }
+
+internal fun parseIsFlagMode(mode: String?): Boolean = mode == "flag"

--- a/app/src/main/java/yt/javi/gridirontimer/presentation/viewmodel/AppTimerSettings.kt
+++ b/app/src/main/java/yt/javi/gridirontimer/presentation/viewmodel/AppTimerSettings.kt
@@ -1,0 +1,16 @@
+package yt.javi.gridirontimer.presentation.viewmodel
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+
+object AppTimerSettings {
+    var flagGameDurationMs by mutableStateOf(TimerConfigs.Default.flagGameDurationMs)
+    var tackleGameDurationMs by mutableStateOf(12L * 60L * 1_000L)
+    var timeoutDurationMs by mutableStateOf(TimerConfigs.Default.timeoutDurationMs)
+
+    fun asTimerConfig(): TimerConfig = TimerConfigs.Default.copy(
+        flagGameDurationMs = flagGameDurationMs,
+        timeoutDurationMs = timeoutDurationMs
+    )
+}

--- a/app/src/main/java/yt/javi/gridirontimer/presentation/viewmodel/TimeoutViewModel.kt
+++ b/app/src/main/java/yt/javi/gridirontimer/presentation/viewmodel/TimeoutViewModel.kt
@@ -17,11 +17,11 @@ class TimeoutViewModel(
     private val _state = MutableStateFlow<TimerState>(TimerState.Idle)
     val state: StateFlow<TimerState> = _state.asStateFlow()
 
-    fun startTimer() {
+    fun startTimer(durationMs: Long = timerConfig.timeoutDurationMs) {
         timer?.cancel()
         _state.value = TimerState.Running
         timer = countdownScheduler.create(
-            timerConfig.timeoutDurationMs,
+            durationMs,
             timerConfig.tickIntervalMs,
             onTick = { millisUntilFinished ->
                 _time.value = millisUntilFinished

--- a/app/src/main/java/yt/javi/gridirontimer/presentation/views/CustomTimerScreen.kt
+++ b/app/src/main/java/yt/javi/gridirontimer/presentation/views/CustomTimerScreen.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -50,8 +52,11 @@ fun CustomTimerScreen(navController: NavController) {
         contentAlignment = Alignment.Center
     ) {
         Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState()),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center
+            verticalArrangement = Arrangement.Top
         ) {
             Text(
                 text = stringResource(R.string.settings),

--- a/app/src/main/java/yt/javi/gridirontimer/presentation/views/CustomTimerScreen.kt
+++ b/app/src/main/java/yt/javi/gridirontimer/presentation/views/CustomTimerScreen.kt
@@ -30,11 +30,13 @@ import androidx.wear.compose.material.ButtonDefaults
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
 import yt.javi.gridirontimer.R
-import yt.javi.gridirontimer.presentation.MainActivity.Screen.Timer
+import yt.javi.gridirontimer.presentation.viewmodel.AppTimerSettings
 
 @Composable
 fun CustomTimerScreen(navController: NavController) {
-    var minutes by remember { mutableIntStateOf(0) }
+    var flagMinutes by remember { mutableIntStateOf((AppTimerSettings.flagGameDurationMs / 60_000L).toInt()) }
+    var tackleMinutes by remember { mutableIntStateOf((AppTimerSettings.tackleGameDurationMs / 60_000L).toInt()) }
+    var timeoutSeconds by remember { mutableIntStateOf((AppTimerSettings.timeoutDurationMs / 1_000L).toInt()) }
     val bg = Brush.radialGradient(
         colors = listOf(Color(0xFF16243A), MaterialTheme.colors.background),
         radius = 360f
@@ -52,43 +54,87 @@ fun CustomTimerScreen(navController: NavController) {
             verticalArrangement = Arrangement.Center
         ) {
             Text(
-                text = "Select minutes",
+                text = stringResource(R.string.settings),
                 style = TextStyle(fontSize = 16.sp, fontWeight = FontWeight.SemiBold, color = MaterialTheme.colors.onSurface)
             )
 
-            Row(
-                horizontalArrangement = Arrangement.Center,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Button(
-                    onClick = { minutes = (minutes - 1).coerceAtLeast(0) },
-                    colors = ButtonDefaults.secondaryButtonColors()
-                ) {
-                    Text("-")
-                }
-                Spacer(modifier = Modifier.width(16.dp))
-                Text(
-                    text = "$minutes",
-                    style = TextStyle(fontSize = 34.sp, fontWeight = FontWeight.ExtraBold, color = MaterialTheme.colors.onBackground)
-                )
-                Spacer(modifier = Modifier.width(16.dp))
-                Button(
-                    onClick = { minutes++ },
-                    colors = ButtonDefaults.primaryButtonColors()
-                ) {
-                    Text("+")
-                }
-            }
+            Spacer(modifier = Modifier.height(8.dp))
+            SettingStepper(
+                label = stringResource(R.string.flag_game_clock),
+                valueText = "$flagMinutes min",
+                onDecrease = { flagMinutes = (flagMinutes - 1).coerceAtLeast(1) },
+                onIncrease = { flagMinutes += 1 }
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+            SettingStepper(
+                label = stringResource(R.string.tackle_game_clock),
+                valueText = "$tackleMinutes min",
+                onDecrease = { tackleMinutes = (tackleMinutes - 1).coerceAtLeast(1) },
+                onIncrease = { tackleMinutes += 1 }
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+            SettingStepper(
+                label = stringResource(R.string.timeout_clock),
+                valueText = "$timeoutSeconds s",
+                onDecrease = { timeoutSeconds = (timeoutSeconds - 5).coerceAtLeast(5) },
+                onIncrease = { timeoutSeconds += 5 }
+            )
+
             Spacer(modifier = Modifier.height(12.dp))
             Button(
                 onClick = {
-                    navController.navigate(Timer.createRoute(minutes * 60L * 1000L))
+                    AppTimerSettings.flagGameDurationMs = flagMinutes * 60L * 1_000L
+                    AppTimerSettings.tackleGameDurationMs = tackleMinutes * 60L * 1_000L
+                    AppTimerSettings.timeoutDurationMs = timeoutSeconds * 1_000L
+                    navController.popBackStack()
                 },
                 modifier = Modifier.width(110.dp),
                 colors = ButtonDefaults.primaryButtonColors()
             ) {
-                Text(stringResource(R.string.start))
+                Text(stringResource(R.string.save))
             }
+        }
+    }
+}
+
+@Composable
+private fun SettingStepper(
+    label: String,
+    valueText: String,
+    onDecrease: () -> Unit,
+    onIncrease: () -> Unit
+) {
+    Text(
+        text = label,
+        style = TextStyle(
+            fontSize = 12.sp,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colors.onSurface
+        )
+    )
+    Row(
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Button(
+            onClick = onDecrease,
+            colors = ButtonDefaults.secondaryButtonColors()
+        ) {
+            Text("-")
+        }
+        Spacer(modifier = Modifier.width(10.dp))
+        Text(
+            text = valueText,
+            style = TextStyle(fontSize = 20.sp, fontWeight = FontWeight.ExtraBold, color = MaterialTheme.colors.onBackground)
+        )
+        Spacer(modifier = Modifier.width(10.dp))
+        Button(
+            onClick = onIncrease,
+            colors = ButtonDefaults.primaryButtonColors()
+        ) {
+            Text("+")
         }
     }
 }

--- a/app/src/main/java/yt/javi/gridirontimer/presentation/views/MainScreen.kt
+++ b/app/src/main/java/yt/javi/gridirontimer/presentation/views/MainScreen.kt
@@ -5,9 +5,11 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.background
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.width
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
@@ -76,9 +78,10 @@ fun MainScreen(navController: NavController) {
             Column(
                 modifier = Modifier
                     .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
                     .padding(10.dp),
                 horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center
+                verticalArrangement = Arrangement.Top
             ) {
                 Text(
                     text = stringResource(R.string.app_name),

--- a/app/src/main/java/yt/javi/gridirontimer/presentation/views/MainScreen.kt
+++ b/app/src/main/java/yt/javi/gridirontimer/presentation/views/MainScreen.kt
@@ -39,10 +39,13 @@ import androidx.wear.tooling.preview.devices.WearDevices
 import yt.javi.gridirontimer.R
 import yt.javi.gridirontimer.presentation.MainActivity.Screen
 import yt.javi.gridirontimer.presentation.theme.GridironTimerTheme
+import yt.javi.gridirontimer.presentation.viewmodel.AppTimerSettings
 
 @Composable
 fun MainScreen(navController: NavController) {
     var reveal by remember { mutableStateOf(false) }
+    val flagDurationMs = AppTimerSettings.flagGameDurationMs
+    val tackleDurationMs = AppTimerSettings.tackleGameDurationMs
     LaunchedEffect(Unit) { reveal = true }
     val titleAlpha by animateFloatAsState(
         targetValue = if (reveal) 1f else 0f,
@@ -88,7 +91,7 @@ fun MainScreen(navController: NavController) {
                 )
                 Spacer(modifier = Modifier.height(8.dp))
                 Button(
-                    onClick = { navController.navigate(Screen.Timer.createRoute(20L * 60L * 1000L)) },
+                    onClick = { navController.navigate(Screen.Timer.createRoute(flagDurationMs, isFlagMode = true)) },
                     modifier = Modifier
                         .width(124.dp)
                         .height(44.dp)
@@ -102,7 +105,7 @@ fun MainScreen(navController: NavController) {
                 }
                 Spacer(modifier = Modifier.height(8.dp))
                 Button(
-                    onClick = { navController.navigate(Screen.Timer.createRoute(12L * 60L * 1000L)) },
+                    onClick = { navController.navigate(Screen.Timer.createRoute(tackleDurationMs, isFlagMode = false)) },
                     modifier = Modifier
                         .width(124.dp)
                         .height(44.dp)
@@ -112,6 +115,19 @@ fun MainScreen(navController: NavController) {
                     Text(
                         text = stringResource(R.string.tackle),
                         style = TextStyle(fontSize = 17.sp, fontWeight = FontWeight.Bold)
+                    )
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+                Button(
+                    onClick = { navController.navigate(Screen.CustomTimer.route) },
+                    modifier = Modifier
+                        .width(124.dp)
+                        .height(36.dp),
+                    colors = ButtonDefaults.secondaryButtonColors()
+                ) {
+                    Text(
+                        text = stringResource(R.string.settings),
+                        style = TextStyle(fontSize = 14.sp, fontWeight = FontWeight.SemiBold)
                     )
                 }
             }

--- a/app/src/main/java/yt/javi/gridirontimer/presentation/views/TimerScreen.kt
+++ b/app/src/main/java/yt/javi/gridirontimer/presentation/views/TimerScreen.kt
@@ -95,7 +95,7 @@ fun createTimerScreenViewModels(): TimerScreenViewModels = TimerScreenViewModels
 fun TimerScreen(
     duration: Long,
     navController: NavController,
-    initialDuration: Long,
+    isFlagMode: Boolean,
     timerConfig: TimerConfig = TimerConfigs.Default,
     viewModels: TimerScreenViewModels = createTimerScreenViewModels(),
     onStemPrimaryHandlerChange: (((() -> Unit)?) -> Unit)? = null,
@@ -111,7 +111,6 @@ fun TimerScreen(
     val sevenSecondClockRemaining by viewModels.sevenSecondClockViewModel.time.collectAsState()
     val timeoutState by viewModels.timeoutViewModel.state.collectAsState()
     val timeoutTimeRemaining by viewModels.timeoutViewModel.time.collectAsState()
-    val isFlagMode = TimerRules.isFlagMode(initialDuration, timerConfig)
     val activePlayClockState = if (isFlagMode && sevenSecondClockState in listOf(TimerState.Running, TimerState.Paused)) {
         sevenSecondClockState
     } else {
@@ -212,7 +211,8 @@ fun TimerScreen(
                         ),
                 playClockPresetDuration = playClockPresetDuration,
                 flagActiveButton = flagActiveButton,
-                gameClockDuration = duration
+                gameClockDuration = duration,
+                timeoutDurationMs = timerConfig.timeoutDurationMs
                     )
                 } else {
                     TimeOutScreen(timeoutTimeRemaining, timeoutState, viewModels.timeoutViewModel, gameClockRemaining)
@@ -263,7 +263,8 @@ private fun GameAndPlayClockScreen(
     callbacks: GameAndPlayClockScreenCallbacks,
     playClockPresetDuration: Long?,
     flagActiveButton: FlagActiveButton,
-    gameClockDuration: Long
+    gameClockDuration: Long,
+    timeoutDurationMs: Long
 ) {
     GameClockDisplay(
         gameClockRemaining = state.gameClockRemaining,
@@ -283,7 +284,7 @@ private fun GameAndPlayClockScreen(
             flagActiveButton = flagActiveButton
         )
         Spacer(modifier = Modifier.height(10.dp))
-        TimeoutButton(isFlagMode, state, callbacks)
+        TimeoutButton(isFlagMode, state, callbacks, timeoutDurationMs)
     }
 }
 
@@ -369,7 +370,8 @@ private fun PlayClockSelector(
 private fun TimeoutButton(
     isFlagMode: Boolean,
     state: GameAndPlayClockScreenState,
-    callbacks: GameAndPlayClockScreenCallbacks
+    callbacks: GameAndPlayClockScreenCallbacks,
+    timeoutDurationMs: Long
 ) {
     Button(
         onClick = {
@@ -379,7 +381,7 @@ private fun TimeoutButton(
             } else {
                 state.playClockViewModel.cancelTimer()
             }
-            state.timeoutViewModel.startTimer()
+            state.timeoutViewModel.startTimer(timeoutDurationMs)
         },
         modifier = Modifier.width(92.dp),
         colors = ButtonDefaults.secondaryButtonColors()
@@ -568,7 +570,7 @@ fun TimerPreview() {
         TimerScreen(
             duration = TimerConfigs.Default.flagGameDurationMs,
             rememberSwipeDismissableNavController(),
-            initialDuration = TimerConfigs.Default.flagGameDurationMs
+            isFlagMode = true
         )
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,4 +21,9 @@
     <string name="status_running">RUNNING</string>
     <string name="status_paused">PAUSED</string>
     <string name="status_ready">READY</string>
+    <string name="settings">Settings</string>
+    <string name="flag_game_clock">Flag game clock</string>
+    <string name="tackle_game_clock">Tackle game clock</string>
+    <string name="timeout_clock">Timeout clock</string>
+    <string name="save">Save</string>
 </resources>

--- a/app/src/test/java/yt/javi/gridirontimer/presentation/MainActivityNavigationTest.kt
+++ b/app/src/test/java/yt/javi/gridirontimer/presentation/MainActivityNavigationTest.kt
@@ -1,0 +1,31 @@
+package yt.javi.gridirontimer.presentation
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MainActivityNavigationTest {
+
+    @Test
+    fun `timer route includes flag mode`() {
+        val route = MainActivity.Screen.Timer.createRoute(1_200_000L, isFlagMode = true)
+
+        assertEquals("timer/1200000/flag", route)
+    }
+
+    @Test
+    fun `timer route includes tackle mode`() {
+        val route = MainActivity.Screen.Timer.createRoute(720_000L, isFlagMode = false)
+
+        assertEquals("timer/720000/tackle", route)
+    }
+
+    @Test
+    fun `parseIsFlagMode returns true only for flag`() {
+        assertTrue(parseIsFlagMode("flag"))
+        assertFalse(parseIsFlagMode("tackle"))
+        assertFalse(parseIsFlagMode(null))
+        assertFalse(parseIsFlagMode("other"))
+    }
+}

--- a/app/src/test/java/yt/javi/gridirontimer/presentation/viewmodel/AppTimerSettingsTest.kt
+++ b/app/src/test/java/yt/javi/gridirontimer/presentation/viewmodel/AppTimerSettingsTest.kt
@@ -1,0 +1,51 @@
+package yt.javi.gridirontimer.presentation.viewmodel
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AppTimerSettingsTest {
+
+    @Test
+    fun `asTimerConfig reflects updated flag and timeout values`() {
+        val originalFlag = AppTimerSettings.flagGameDurationMs
+        val originalTackle = AppTimerSettings.tackleGameDurationMs
+        val originalTimeout = AppTimerSettings.timeoutDurationMs
+
+        try {
+            AppTimerSettings.flagGameDurationMs = 900_000L
+            AppTimerSettings.tackleGameDurationMs = 600_000L
+            AppTimerSettings.timeoutDurationMs = 45_000L
+
+            val config = AppTimerSettings.asTimerConfig()
+
+            assertEquals(900_000L, config.flagGameDurationMs)
+            assertEquals(45_000L, config.timeoutDurationMs)
+            assertEquals(TimerConfigs.Default.flagPlayClockMs, config.flagPlayClockMs)
+        } finally {
+            AppTimerSettings.flagGameDurationMs = originalFlag
+            AppTimerSettings.tackleGameDurationMs = originalTackle
+            AppTimerSettings.timeoutDurationMs = originalTimeout
+        }
+    }
+
+    @Test
+    fun `settings values can be updated independently`() {
+        val originalFlag = AppTimerSettings.flagGameDurationMs
+        val originalTackle = AppTimerSettings.tackleGameDurationMs
+        val originalTimeout = AppTimerSettings.timeoutDurationMs
+
+        try {
+            AppTimerSettings.flagGameDurationMs = 1_500_000L
+            AppTimerSettings.tackleGameDurationMs = 900_000L
+            AppTimerSettings.timeoutDurationMs = 30_000L
+
+            assertEquals(1_500_000L, AppTimerSettings.flagGameDurationMs)
+            assertEquals(900_000L, AppTimerSettings.tackleGameDurationMs)
+            assertEquals(30_000L, AppTimerSettings.timeoutDurationMs)
+        } finally {
+            AppTimerSettings.flagGameDurationMs = originalFlag
+            AppTimerSettings.tackleGameDurationMs = originalTackle
+            AppTimerSettings.timeoutDurationMs = originalTimeout
+        }
+    }
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,7 +12,7 @@ sonar.kotlin.file.suffixes=.kt
 
 # Coverage (Kover XML uses JaCoCo format)
 sonar.coverage.jacoco.xmlReportPaths=app/build/reports/kover/reportDebug.xml,app/build/reports/kover/report.xml
-sonar.coverage.exclusions=**/*Composable*,**/presentation/views/**,**/presentation/theme/**
+sonar.coverage.exclusions=**/*Composable*,**/presentation/views/**,**/presentation/theme/**,**/presentation/MainActivity.kt
 
 # Execution paths 
 sonar.java.binaries=app/build/intermediates/compile_app_classes_jar/debug


### PR DESCRIPTION
## Summary
- Add a Settings button on the main screen
- Add settings screen to configure Flag game clock, Tackle game clock, and Timeout clock
- Apply configured values when starting Flag/Tackle timers
- Apply configured timeout duration when pressing TO
- Pass explicit game mode (flag/tackle) in timer navigation route

## Notes
- This is a new PR because #26 is already merged.

## Validation
- ./gradlew compileDebugKotlin --parallel --build-cache ✅
- ./gradlew testDebugUnitTest --parallel --build-cache ✅